### PR TITLE
Clean imports and style

### DIFF
--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict, Any
 import yaml
 from pydantic import BaseModel
 

--- a/docpipe/extractors/base.py
+++ b/docpipe/extractors/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
-from pathlib import Path
+from typing import Dict, Any
 
 class BaseExtractor(ABC):
     """Base class for all document extractors"""

--- a/docpipe/extractors/youtube.py
+++ b/docpipe/extractors/youtube.py
@@ -1,6 +1,4 @@
 import re
-import subprocess
-import json
 from pathlib import Path
 from typing import Dict, Any, Optional
 import yt_dlp

--- a/text_agent/docpipe/config.py
+++ b/text_agent/docpipe/config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict, Any
 import yaml
 from pydantic import BaseModel
 

--- a/text_agent/docpipe/extractors/base.py
+++ b/text_agent/docpipe/extractors/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
-from pathlib import Path
+from typing import Dict, Any
 
 class BaseExtractor(ABC):
     """Base class for all document extractors"""

--- a/text_agent/docpipe/extractors/youtube.py
+++ b/text_agent/docpipe/extractors/youtube.py
@@ -1,6 +1,4 @@
 import re
-import subprocess
-import json
 from pathlib import Path
 from typing import Dict, Any, Optional
 import yt_dlp

--- a/translation/gpt_translate.py
+++ b/translation/gpt_translate.py
@@ -1,4 +1,6 @@
-import os, textwrap, tiktoken, openai
+import os
+import tiktoken
+import openai
 
 class GPT4OMiniTranslator:
     """
@@ -46,3 +48,4 @@ class GPT4OMiniTranslator:
             out.append(resp.choices[0].message.content.strip())
         print("✓ done")
         return "\n".join(out)
+

--- a/translation/translate.py
+++ b/translation/translate.py
@@ -1,5 +1,7 @@
 if __name__ == "__main__":
-    import argparse, pathlib, sys
+    import argparse
+    import pathlib
+    import sys
     ap = argparse.ArgumentParser()
     ap.add_argument("src", help="input .txt file or '-' for STDIN")
     ap.add_argument("-o", "--out", help="save to file")
@@ -23,7 +25,7 @@ if __name__ == "__main__":
         if args.out:
             print(f"Saving translation to: {args.out}")
             pathlib.Path(args.out).write_text(ja, encoding='utf-8')
-            print(f"Translation saved successfully")
+            print("Translation saved successfully")
         else:
             print(ja)
     except Exception as e:
@@ -31,3 +33,4 @@ if __name__ == "__main__":
         import traceback
         traceback.print_exc()
         sys.exit(1)
+


### PR DESCRIPTION
## Summary
- clean up unused imports
- fix CLI translation script style

## Testing
- `ruff check docpipe translation count_words.py text_agent`
- `pytest -q` *(fails: missing ffmpeg and tries to download models)*

------
https://chatgpt.com/codex/tasks/task_e_683a3f457bb88322ae8284f519761a9b