### PR TITLE
Implement web extractor

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -5,6 +5,7 @@ from .config import Config
 from .extractors.youtube import YouTubeExtractor
 from .extractors.pdf import PDFExtractor
 from .extractors.ocr_pdf import OCRPDFExtractor
+from .extractors.web import WebExtractor
 from .extractors.audio import AudioExtractor
 import json
 import hashlib
@@ -29,6 +30,7 @@ def process(sources: List[str], config: str, output_dir: str):
     # Initialize extractors
     extractors = [
         YouTubeExtractor(cfg.temp_dir),
+        WebExtractor(),
         PDFExtractor(),
         OCRPDFExtractor(),
         AudioExtractor(),

--- a/docpipe/extractors/__init__.py
+++ b/docpipe/extractors/__init__.py
@@ -9,6 +9,11 @@ from .pdf import PDFExtractor
 from .ocr_pdf import OCRPDFExtractor
 
 try:  # Optional dependency
+    from .web import WebExtractor
+except Exception:  # pragma: no cover - optional
+    WebExtractor = None  # type: ignore
+
+try:  # Optional dependency
     from .audio import AudioExtractor
 except Exception:  # pragma: no cover - optional
     AudioExtractor = None  # type: ignore
@@ -20,4 +25,7 @@ if AudioExtractor is not None:
 
 if YouTubeExtractor is not None:
     __all__.insert(1, "YouTubeExtractor")
+
+if WebExtractor is not None:
+    __all__.insert(1, "WebExtractor")
 

--- a/docpipe/extractors/web.py
+++ b/docpipe/extractors/web.py
@@ -1,0 +1,37 @@
+from typing import Dict, Any
+
+try:
+    import trafilatura  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    trafilatura = None  # type: ignore
+
+from .base import BaseExtractor
+
+
+class WebExtractor(BaseExtractor):
+    """Extractor for web pages using trafilatura."""
+
+    def can_handle(self, source: str) -> bool:
+        """Check if the source is a URL."""
+        return source.lower().startswith("http://") or source.lower().startswith("https://")
+
+    def extract(self, source: str, **kwargs: Any) -> Dict[str, Any]:
+        """Extract main content from a web page."""
+        if trafilatura is None:
+            raise ImportError("trafilatura is required for web extraction")
+
+        downloaded = trafilatura.fetch_url(source)
+        if not downloaded:
+            raise RuntimeError(f"Failed to fetch URL: {source}")
+
+        text = trafilatura.extract(
+            downloaded, include_comments=False, include_tables=False
+        )
+        if text is None:
+            raise RuntimeError(f"Failed to extract content from {source}")
+
+        metadata = {
+            "source_type": "web",
+            "url": source,
+        }
+        return {"text": text, "metadata": metadata}

--- a/docpipe/tests/test_web.py
+++ b/docpipe/tests/test_web.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.extractors.web import WebExtractor
+
+
+def _dummy_trafilatura_module(fetch_returns="DUMMY", extract_returns="TEXT"):
+    return types.SimpleNamespace(
+        fetch_url=lambda url: fetch_returns,
+        extract=lambda html, include_comments=False, include_tables=False: extract_returns,
+    )
+
+
+def test_can_handle_web():
+    extractor = WebExtractor()
+    assert extractor.can_handle("https://example.com")
+    assert not extractor.can_handle("file.pdf")
+
+
+def test_extract_success(monkeypatch):
+    monkeypatch.setattr(
+        "docpipe.extractors.web.trafilatura",
+        _dummy_trafilatura_module(),
+    )
+    extractor = WebExtractor()
+    result = extractor.extract("https://example.com")
+    assert result["text"] == "TEXT"
+    assert result["metadata"]["source_type"] == "web"
+
+
+def test_extract_missing_dependency(monkeypatch):
+    monkeypatch.setattr("docpipe.extractors.web.trafilatura", None)
+    extractor = WebExtractor()
+    try:
+        extractor.extract("https://example.com")
+    except ImportError:
+        assert True
+    else:
+        assert False, "ImportError not raised"
+
+
+def test_extract_fetch_failure(monkeypatch):
+    monkeypatch.setattr(
+        "docpipe.extractors.web.trafilatura",
+        _dummy_trafilatura_module(fetch_returns=None),
+    )
+    extractor = WebExtractor()
+    try:
+        extractor.extract("https://example.com")
+    except RuntimeError:
+        assert True
+    else:
+        assert False, "RuntimeError not raised"


### PR DESCRIPTION
## Summary
- add a `WebExtractor` that uses `trafilatura` to pull page text
- expose `WebExtractor` through module imports and CLI
- test the new extractor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7058647c832294633b9a85975566