### PR TITLE
Improve CLI types and refactor tests

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -1,6 +1,6 @@
 import click
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from .config import Config
 from .extractors.youtube import YouTubeExtractor
 from .extractors.pdf import PDFExtractor
@@ -20,7 +20,7 @@ def cli():
 @click.argument('sources', nargs=-1, required=True)
 @click.option('--config', '-c', type=click.Path(exists=True), help='Path to config file')
 @click.option('--output-dir', '-o', type=click.Path(), help='Output directory')
-def process(sources: List[str], config: str, output_dir: str):
+def process(sources: List[str], config: Optional[str], output_dir: Optional[str]) -> None:
     """Process one or more document sources"""
     # Load config
     cfg = Config.from_yaml(config) if config else Config()

--- a/docpipe/tests/test_audio.py
+++ b/docpipe/tests/test_audio.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
@@ -32,12 +33,8 @@ def test_can_handle_audio(monkeypatch):
 def test_extract_file_not_found(monkeypatch):
     monkeypatch.setattr("docpipe.extractors.audio.whisper", _dummy_whisper_module())
     extractor = AudioExtractor()
-    try:
+    with pytest.raises(FileNotFoundError):
         extractor.extract("missing.mp3")
-    except FileNotFoundError:
-        assert True
-    else:
-        assert False, "FileNotFoundError not raised"
 
 
 def test_extract_success(tmp_path, monkeypatch):

--- a/docpipe/tests/test_ocr_pdf.py
+++ b/docpipe/tests/test_ocr_pdf.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
@@ -32,9 +33,5 @@ def test_extract_missing_dependency(tmp_path, monkeypatch):
     monkeypatch.setattr("docpipe.extractors.ocr_pdf.marker_ocr_pdf", None)
 
     extractor = OCRPDFExtractor()
-    try:
+    with pytest.raises(ImportError):
         extractor.extract(str(fake_pdf))
-    except ImportError:
-        assert True
-    else:
-        assert False, "ImportError not raised"


### PR DESCRIPTION
## Summary
- add Optional typing for CLI arguments
- refactor tests to use `pytest.raises`

## Testing
- `ruff check .`
- `mypy docpipe`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a7135ad588322b09580937c0dbe93