### PR TITLE
Fix tests import order

### DIFF
--- a/docpipe/__init__.py
+++ b/docpipe/__init__.py
@@ -2,4 +2,4 @@
 Document Pipeline System - A unified document conversion framework
 """
 
-__version__ = "1.0.0" 
+__version__ = "1.0.0"

--- a/docpipe/tests/test_audio.py
+++ b/docpipe/tests/test_audio.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from docpipe.extractors.audio import AudioExtractor
+from docpipe.extractors.audio import AudioExtractor  # noqa: E402
 
 
 def _dummy_whisper_module():
@@ -13,9 +13,7 @@ def _dummy_whisper_module():
         def transcribe(path, language=None, verbose=False):
             return {
                 "text": "hello world",
-                "segments": [
-                    {"start": 0.0, "end": 1.0, "text": "hello world"}
-                ],
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hello world"}],
             }
 
         return types.SimpleNamespace(transcribe=transcribe)

--- a/docpipe/tests/test_ocr_pdf.py
+++ b/docpipe/tests/test_ocr_pdf.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from docpipe.extractors.ocr_pdf import OCRPDFExtractor
+from docpipe.extractors.ocr_pdf import OCRPDFExtractor  # noqa: E402
 
 
 def test_can_handle_pdf():

--- a/docpipe/tests/test_preprocessor.py
+++ b/docpipe/tests/test_preprocessor.py
@@ -3,14 +3,17 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from docpipe.processors.preprocessor import Preprocessor
+from docpipe.processors.preprocessor import Preprocessor  # noqa: E402
 
 
 def test_restore_line_breaks_and_format():
     text = "This is a line\nbroken in the middle\nof a sentence.\n\nAnother line."
     pre = Preprocessor()
     processed = pre.process(text)
-    assert processed == "This is a line broken in the middle of a sentence.\n\nAnother line."
+    assert (
+        processed
+        == "This is a line broken in the middle of a sentence.\n\nAnother line."
+    )
 
 
 def test_correct_ocr_errors():

--- a/docpipe/tests/test_proofreader.py
+++ b/docpipe/tests/test_proofreader.py
@@ -4,7 +4,7 @@ import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from docpipe.processors.proofreader import Proofreader
+from docpipe.processors.proofreader import Proofreader  # noqa: E402
 
 
 def _dummy_language_tool_module():
@@ -25,7 +25,9 @@ def _dummy_language_tool_module():
 
 
 def test_proofread_no_errors(monkeypatch):
-    monkeypatch.setattr("docpipe.processors.proofreader.lt", _dummy_language_tool_module())
+    monkeypatch.setattr(
+        "docpipe.processors.proofreader.lt", _dummy_language_tool_module()
+    )
     pf = Proofreader()
     result = pf.process("This is fine.")
     assert result["text"] == "This is fine."
@@ -33,7 +35,9 @@ def test_proofread_no_errors(monkeypatch):
 
 
 def test_proofread_correction(monkeypatch):
-    monkeypatch.setattr("docpipe.processors.proofreader.lt", _dummy_language_tool_module())
+    monkeypatch.setattr(
+        "docpipe.processors.proofreader.lt", _dummy_language_tool_module()
+    )
     pf = Proofreader()
     result = pf.process("This is a mistkae.")
     assert result["text"] == "This is a mistake."

--- a/docpipe/tests/test_web.py
+++ b/docpipe/tests/test_web.py
@@ -4,7 +4,7 @@ import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from docpipe.extractors.web import WebExtractor
+from docpipe.extractors.web import WebExtractor  # noqa: E402
 
 
 def _dummy_trafilatura_module(fetch_returns="DUMMY", extract_returns="TEXT"):


### PR DESCRIPTION
## Summary
- fix trailing whitespace in package init
- mark imports in tests with `# noqa: E402`

## Testing
- `pytest -q`
- `mypy docpipe --ignore-missing-imports`

------
https://chatgpt.com/codex/tasks/task_e_683a7785119c832293329843a9b741c4