### PR TITLE
Implement Fixer Agent

### DIFF
--- a/docpipe/processors/__init__.py
+++ b/docpipe/processors/__init__.py
@@ -1,4 +1,5 @@
 from .preprocessor import Preprocessor
+from .fixer import Fixer
 
 try:  # Optional dependency
     from .evaluator import Evaluator
@@ -10,7 +11,7 @@ try:  # Optional dependency
 except Exception:  # pragma: no cover - optional
     Proofreader = None  # type: ignore
 
-__all__ = ["Preprocessor"]
+__all__ = ["Preprocessor", "Fixer"]
 
 if Proofreader is not None:
     __all__.append("Proofreader")

--- a/docpipe/processors/fixer.py
+++ b/docpipe/processors/fixer.py
@@ -1,0 +1,39 @@
+import re
+from typing import Any, Dict
+
+class Fixer:
+    """Simple error correction agent."""
+
+    def remove_duplicate_lines(self, text: str) -> str:
+        lines = text.splitlines()
+        cleaned = []
+        for line in lines:
+            if not cleaned or line != cleaned[-1]:
+                cleaned.append(line)
+        return "\n".join(cleaned)
+
+    def balance_parentheses(self, text: str) -> str:
+        diff = text.count("(") - text.count(")")
+        if diff > 0:
+            text += ")" * diff
+        elif diff < 0:
+            text = "(" * (-diff) + text
+        return text
+
+    def fix_common_typos(self, text: str) -> str:
+        corrections = {
+            r"\bteh\b": "the",
+            r"\brecieve\b": "receive",
+        }
+        for pattern, repl in corrections.items():
+            text = re.sub(pattern, repl, text, flags=re.IGNORECASE)
+        text = re.sub(r" {2,}", " ", text)
+        return text
+
+    def process(self, text: str) -> Dict[str, Any]:
+        original = text
+        text = self.remove_duplicate_lines(text)
+        text = self.balance_parentheses(text)
+        text = self.fix_common_typos(text)
+        changed = text != original
+        return {"text": text, "changed": changed}

--- a/docpipe/tests/test_fixer.py
+++ b/docpipe/tests/test_fixer.py
@@ -1,0 +1,27 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.processors.fixer import Fixer  # noqa: E402
+
+
+def test_remove_duplicate_lines():
+    fixer = Fixer()
+    text = "Line1\nLine1\nLine2"
+    result = fixer.process(text)
+    assert result["text"] == "Line1\nLine2"
+    assert result["changed"]
+
+
+def test_balance_parentheses():
+    fixer = Fixer()
+    text = "Example (text"
+    result = fixer.process(text)
+    assert result["text"].endswith(")")
+
+
+def test_fix_common_typos():
+    fixer = Fixer()
+    text = "teh quick brown fox"
+    result = fixer.process(text)
+    assert "the quick brown fox" == result["text"]


### PR DESCRIPTION
## Summary
- add Fixer agent for pattern-based text corrections
- export Fixer through `docpipe.processors`
- test Fixer behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7b5930c483229d40481e4c8e4cd9