### PR TITLE
Add default configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ Process multiple documents:
 python -m docpipe.cli process "doc1.pdf" "doc2.mp3" "https://youtube.com/watch?v=..."
 ```
 
-Process with custom configuration:
+Process with custom configuration (reads `config.yaml` automatically):
 ```bash
-python -m docpipe.cli process --config config.yaml --output-dir output/ "input.pdf"
+python -m docpipe.cli process --output-dir output/ "input.pdf"
 ```
+You can specify a different file with `--config path/to/file.yaml`.
 
 ### Configuration
 
@@ -77,6 +78,7 @@ output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"
 ```
+This file will be loaded automatically when running the CLI from the same directory.
 
 ## Development
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+pipeline:
+  quality_threshold: 0.85
+  max_retries: 3
+  min_improvement: 0.01
+  language_tool_threshold: 0.02
+  bleu_threshold: 35.0
+
+llm:
+  profile: "default"  # or "local"
+  model: "gpt-4"
+  temperature: 0.7
+
+output_dir: "output"
+temp_dir: "temp"
+log_dir: "logs"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -18,13 +18,12 @@ def cli():
     pass
 
 @cli.command()
-@click.argument('sources', nargs=-1, required=True)
-@click.option('--config', '-c', type=click.Path(exists=True), help='Path to config file')
-@click.option('--output-dir', '-o', type=click.Path(), help='Output directory')
+@click.argument("sources", nargs=-1, required=True)
+@click.option("--config", "-c", type=click.Path(exists=True), help="Path to config file")
+@click.option("--output-dir", "-o", type=click.Path(), help="Output directory")
 def process(sources: List[str], config: Optional[str], output_dir: Optional[str]) -> None:
     """Process one or more document sources"""
-    # Load config
-    cfg = Config.from_yaml(config) if config else Config()
+    cfg = Config.load(config)
     if output_dir:
         cfg.output_dir = Path(output_dir)
     

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from pathlib import Path
+
+from docpipe.config import Config
+
+
+def test_load_default_file(tmp_path, monkeypatch):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("llm:\n  model: gpt-3\n")
+
+    # change working directory to tmp_path
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+    assert cfg.llm.model == "gpt-3"
+
+
+def test_load_no_file(tmp_path, monkeypatch):
+    pytest.importorskip("yaml")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+    assert cfg.pipeline.quality_threshold == 0.85
+
+


### PR DESCRIPTION
## Summary
- add `config.yaml` template
- load `config.yaml` automatically via `Config.load`
- update CLI to use the new loading logic
- document default configuration behavior
- add tests for configuration loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a85b4836083229bf241b65e920dde