### PR TITLE
Fix lint issues in tests

### DIFF
--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-from pathlib import Path
 
 from docpipe.config import Config
 

--- a/docpipe/tests/test_evaluator.py
+++ b/docpipe/tests/test_evaluator.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import types
-import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 

--- a/docpipe/tests/test_youtube.py
+++ b/docpipe/tests/test_youtube.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import types
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))


### PR DESCRIPTION
## Summary
- remove unused imports that `ruff` flagged

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a87359cd88322b7746111914eaf36