### PR TITLE
Use config thresholds in quality control

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -7,7 +7,8 @@ from .extractors.pdf import PDFExtractor
 from .extractors.ocr_pdf import OCRPDFExtractor
 from .extractors.web import WebExtractor
 from .extractors.audio import AudioExtractor
-from .processors import Preprocessor
+from .processors import Preprocessor, Translator, Proofreader, Evaluator, Fixer
+from .pipeline import process_text
 import json
 import hashlib
 import re
@@ -37,6 +38,10 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         # TODO: Add other extractors
     ]
     preprocessor = Preprocessor()
+    translator = Translator(cfg.llm.model, cfg.llm.temperature)
+    proofreader = Proofreader()
+    evaluator = Evaluator()
+    fixer = Fixer()
     
     # Process each source
     for source in sources:
@@ -58,8 +63,18 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
             click.echo(f"Error: No extractor succeeded for {source}", err=True)
             continue
 
-        # Preprocess text
-        result["text"] = preprocessor.process(result["text"])
+        # Run processing pipeline with quality control
+        pipeline_result = process_text(
+            result["text"],
+            cfg,
+            preprocessor=preprocessor,
+            translator=translator,
+            proofreader=proofreader,
+            evaluator=evaluator,
+            fixer=fixer,
+        )
+        result["text"] = pipeline_result["text"]
+        result["metadata"].update(pipeline_result["metadata"])
 
         # Save output
         digest = hashlib.sha1(source.encode("utf-8")).hexdigest()[:8]

--- a/docpipe/pipeline.py
+++ b/docpipe/pipeline.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .config import Config
+from .processors import Preprocessor, Translator, Proofreader, Evaluator, Fixer
+
+
+def process_text(
+    text: str,
+    cfg: Config,
+    preprocessor: Preprocessor | None = None,
+    translator: Translator | None = None,
+    proofreader: Proofreader | None = None,
+    evaluator: Evaluator | None = None,
+    fixer: Fixer | None = None,
+) -> Dict[str, Any]:
+    """Run the full processing pipeline with quality control."""
+
+    pre = preprocessor or Preprocessor()
+    tr = translator or Translator(cfg.llm.model, cfg.llm.temperature)
+    pr = proofreader or Proofreader()
+    ev = evaluator or Evaluator()
+    fx = fixer or Fixer()
+
+    # Preprocess and translate
+    text = pre.process(text)
+    trans_res = tr.process(text)
+    text = trans_res["text"]
+    metadata: Dict[str, Any] = dict(trans_res.get("metadata", {}))
+
+    # Initial proofreading and evaluation
+    pf_res = pr.process(text)
+    text = pf_res["text"]
+    quality = ev.evaluate(text)["quality_score"]
+    retries = 0
+    prev_quality = quality
+
+    # Quality control loop
+    while (
+        quality < cfg.pipeline.quality_threshold
+        and retries < cfg.pipeline.max_retries
+    ):
+        fix_res = fx.process(text)
+        text = fix_res["text"]
+        quality = ev.evaluate(text)["quality_score"]
+        improvement = quality - prev_quality
+        if improvement < cfg.pipeline.min_improvement:
+            break
+        prev_quality = quality
+        retries += 1
+
+    metadata["retries"] = retries
+    metadata["quality_score"] = quality
+    return {"text": text, "metadata": metadata, "quality_score": quality}

--- a/docpipe/processors/__init__.py
+++ b/docpipe/processors/__init__.py
@@ -2,6 +2,11 @@ from .preprocessor import Preprocessor
 from .fixer import Fixer
 
 try:  # Optional dependency
+    from .translator import Translator
+except Exception:  # pragma: no cover - optional
+    Translator = None  # type: ignore
+
+try:  # Optional dependency
     from .evaluator import Evaluator
 except Exception:  # pragma: no cover - optional
     Evaluator = None  # type: ignore
@@ -12,6 +17,9 @@ except Exception:  # pragma: no cover - optional
     Proofreader = None  # type: ignore
 
 __all__ = ["Preprocessor", "Fixer"]
+
+if Translator is not None:
+    __all__.append("Translator")
 
 if Proofreader is not None:
     __all__.append("Proofreader")

--- a/docpipe/processors/translator.py
+++ b/docpipe/processors/translator.py
@@ -1,0 +1,43 @@
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+import re
+from typing import Any, Dict
+
+
+class Translator:
+    """Simple translator using OpenAI ChatCompletion."""
+
+    def __init__(self, model: str = "gpt-4", temperature: float = 0.7) -> None:
+        if openai is None:
+            raise ImportError("openai is required for Translator")
+        self.model = model
+        self.temperature = temperature
+
+    def detect_language(self, text: str) -> str:
+        """Very naive language detection."""
+        if re.search("[\u3040-\u30ff\u4e00-\u9fff]", text):
+            return "ja"
+        return "en"
+
+    def translate(self, text: str, target_lang: str = "ja") -> str:
+        """Translate text to the target language using ChatCompletion."""
+        if target_lang == self.detect_language(text):
+            return text
+        prompt = f"Translate the following text to {target_lang}:\n" + text
+        resp = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=self.temperature,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+
+    def process(self, text: str) -> Dict[str, Any]:
+        src_lang = self.detect_language(text)
+        translated = self.translate(text, "ja")
+        return {
+            "text": translated,
+            "metadata": {"source_language": src_lang, "model": self.model},
+        }

--- a/docpipe/tests/test_pipeline.py
+++ b/docpipe/tests/test_pipeline.py
@@ -1,0 +1,98 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.pipeline import process_text  # noqa: E402
+from docpipe.config import Config  # noqa: E402
+
+
+class DummyProcessor:
+    def __init__(self, value=None):
+        self.value = value
+
+    def process(self, text):
+        return text if self.value is None else self.value
+
+
+def test_quality_loop_improves(monkeypatch):
+    cfg = Config()
+    cfg.pipeline.quality_threshold = 0.8
+    cfg.pipeline.max_retries = 2
+    cfg.pipeline.min_improvement = 0.0
+
+    class DummyPre( DummyProcessor):
+        def process(self, text):
+            return text
+
+    class DummyTranslator:
+        def process(self, text):
+            return {"text": text, "metadata": {}}
+
+    class DummyProofreader:
+        def process(self, text):
+            return {"text": text, "quality_score": 1.0}
+
+    class DummyEvaluator:
+        def __init__(self):
+            self.calls = 0
+
+        def evaluate(self, text, reference=None):
+            self.calls += 1
+            score = 0.5 if self.calls == 1 else 0.9
+            return {"quality_score": score}
+
+    class DummyFixer:
+        def process(self, text):
+            return {"text": text + " fixed", "changed": True}
+
+    res = process_text(
+        "text",
+        cfg,
+        preprocessor=DummyPre(),
+        translator=DummyTranslator(),
+        proofreader=DummyProofreader(),
+        evaluator=DummyEvaluator(),
+        fixer=DummyFixer(),
+    )
+    assert res["quality_score"] >= cfg.pipeline.quality_threshold
+    assert res["metadata"]["retries"] == 1
+
+
+def test_quality_loop_max_retries(monkeypatch):
+    cfg = Config()
+    cfg.pipeline.quality_threshold = 0.9
+    cfg.pipeline.max_retries = 2
+    cfg.pipeline.min_improvement = 0.0
+
+    class DummyPre(DummyProcessor):
+        def process(self, text):
+            return text
+
+    class DummyTranslator:
+        def process(self, text):
+            return {"text": text, "metadata": {}}
+
+    class DummyProofreader:
+        def process(self, text):
+            return {"text": text, "quality_score": 1.0}
+
+    class DummyEvaluator:
+        def evaluate(self, text, reference=None):
+            return {"quality_score": 0.5}
+
+    class DummyFixer:
+        def process(self, text):
+            return {"text": text, "changed": False}
+
+    res = process_text(
+        "text",
+        cfg,
+        preprocessor=DummyPre(),
+        translator=DummyTranslator(),
+        proofreader=DummyProofreader(),
+        evaluator=DummyEvaluator(),
+        fixer=DummyFixer(),
+    )
+    assert res["quality_score"] < cfg.pipeline.quality_threshold
+    assert res["metadata"]["retries"] == cfg.pipeline.max_retries

--- a/docpipe/tests/test_translator.py
+++ b/docpipe/tests/test_translator.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.processors.translator import Translator  # noqa: E402
+
+
+def _dummy_openai_module(result: str = "翻訳済み"):
+    class DummyChatCompletion:
+        @staticmethod
+        def create(model, messages, temperature=0.0):
+            return {"choices": [{"message": {"content": result}}]}
+
+    return types.SimpleNamespace(ChatCompletion=DummyChatCompletion)
+
+
+def test_translate(monkeypatch):
+    monkeypatch.setattr(
+        "docpipe.processors.translator.openai", _dummy_openai_module("こんにちは")
+    )
+    tr = Translator()
+    out = tr.process("Hello")
+    assert out["text"] == "こんにちは"
+    assert out["metadata"]["source_language"] == "en"
+
+
+def test_detect_language_japanese(monkeypatch):
+    monkeypatch.setattr("docpipe.processors.translator.openai", _dummy_openai_module())
+    tr = Translator()
+    assert tr.detect_language("これは日本語です") == "ja"


### PR DESCRIPTION
## Summary
- add `process_text` pipeline with quality control loop
- use `process_text` in CLI
- test new pipeline behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a8c50dd7c832284dbdcb29e6261d7