### PR TITLE
Add directory input support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Process multiple documents:
 python -m docpipe.cli process "doc1.pdf" "doc2.mp3" "https://youtube.com/watch?v=..."
 ```
 
+Process all files in a folder (non-recursive):
+```bash
+python -m docpipe.cli process path/to/folder/
+```
+
 Process with custom configuration (reads `config.yaml` automatically):
 ```bash
 python -m docpipe.cli process --output-dir output/ "input.pdf"

--- a/docpipe/tests/test_cli.py
+++ b/docpipe/tests/test_cli.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.cli import _expand_sources  # noqa: E402
+
+
+def test_expand_sources(tmp_path):
+    # Create files and a subdirectory
+    file1 = tmp_path / "a.txt"
+    file1.write_text("a")
+    file2 = tmp_path / "b.txt"
+    file2.write_text("b")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.txt").write_text("c")
+
+    sources = [str(file1), str(tmp_path)]
+    expanded = _expand_sources(sources)
+
+    assert str(file1) in expanded
+    assert str(file2) in expanded
+    # subdirectory files should not be included
+    assert str(sub / "c.txt") not in expanded


### PR DESCRIPTION
## Summary
- process CLI expands directory arguments to all files
- update documentation with folder example
- test new `_expand_sources` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab8a90ac4832285638c377c7e888c