### PR TITLE
Handle urls.txt as URL list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Process all files in a folder (non-recursive):
 python -m docpipe.cli process path/to/folder/
 ```
 
+Process URLs listed in `urls.txt`:
+```bash
+python -m docpipe.cli process urls.txt
+```
+Each line of `urls.txt` should contain a web page URL. Lines that do not start
+with `http://` or `https://` are ignored.
+
 Process with custom configuration (reads `config.yaml` automatically):
 ```bash
 python -m docpipe.cli process --output-dir output/ "input.pdf"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 
 def _expand_sources(source_paths: List[str]) -> List[str]:
-    """Expand directory paths into contained file paths (non-recursive)."""
+    """Expand directory paths and special files into individual sources."""
     expanded: List[str] = []
     for src in source_paths:
         p = Path(src)
@@ -12,6 +12,11 @@ def _expand_sources(source_paths: List[str]) -> List[str]:
             for child in p.iterdir():
                 if child.is_file():
                     expanded.append(str(child))
+        elif p.is_file() and p.name == "urls.txt":
+            for line in p.read_text(encoding="utf-8").splitlines():
+                url = line.strip()
+                if url.lower().startswith("http://") or url.lower().startswith("https://"):
+                    expanded.append(url)
         else:
             expanded.append(src)
     return expanded

--- a/docpipe/tests/test_cli.py
+++ b/docpipe/tests/test_cli.py
@@ -24,3 +24,19 @@ def test_expand_sources(tmp_path):
     assert str(file2) in expanded
     # subdirectory files should not be included
     assert str(sub / "c.txt") not in expanded
+
+
+def test_expand_sources_urls_file(tmp_path):
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text(
+        "https://example.com\nnot-a-url\nhttp://example.org/page\n",
+        encoding="utf-8",
+    )
+
+    sources = [str(urls_file)]
+    expanded = _expand_sources(sources)
+
+    assert expanded == [
+        "https://example.com",
+        "http://example.org/page",
+    ]


### PR DESCRIPTION
## Summary
- support reading URLs from `urls.txt` in CLI
- ignore non-URL lines
- document url list processing in README
- add unit test for urls.txt expansion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac0af3b148322b41412237af83db0