### PR TITLE
Add chunk-based pipeline processing

### DIFF
--- a/docpipe/pipeline.py
+++ b/docpipe/pipeline.py
@@ -1,19 +1,19 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from .config import PipelineConfig
 from .processors import Translator, Proofreader, Evaluator, Fixer
+from .utils import split_into_chunks
 
 
-def process_text(
+def _process_chunk(
     text: str,
-
     cfg: PipelineConfig,
     translator: Translator,
     proofreader: Proofreader,
     evaluator: Evaluator,
     fixer: Fixer,
 ) -> Dict[str, Any]:
-    """Run text through translation, proofreading, evaluation and fixing."""
+    """Process a single text chunk through the pipeline."""
     retries = 0
     prev_quality = 0.0
     metadata: Dict[str, Any] = {}
@@ -49,3 +49,50 @@ def process_text(
     metadata["retries"] = retries
 
     return {"text": text, "metadata": metadata}
+
+
+def process_text(
+    text: str,
+
+    cfg: PipelineConfig,
+    translator: Translator,
+    proofreader: Proofreader,
+    evaluator: Evaluator,
+    fixer: Fixer,
+    max_tokens: int = 2048,
+) -> Dict[str, Any]:
+    """Run text through translation, proofreading, evaluation and fixing.
+
+    The text is split into chunks with :func:`split_into_chunks` and each chunk
+    is processed sequentially. Metadata from all chunks is aggregated and
+    returned alongside the concatenated text.
+    """
+
+    chunks = split_into_chunks(text, max_tokens)
+
+    if len(chunks) == 1:
+        return _process_chunk(
+            chunks[0], cfg, translator, proofreader, evaluator, fixer
+        )
+
+    all_text: List[str] = []
+    meta_list: List[Dict[str, Any]] = []
+    quality_sum = 0.0
+    retry_sum = 0
+
+    for chunk in chunks:
+        result = _process_chunk(chunk, cfg, translator, proofreader, evaluator, fixer)
+        all_text.append(result["text"])
+        m = result["metadata"]
+        meta_list.append(m)
+        quality_sum += m.get("quality_score", 0.0)
+        retry_sum += m.get("retries", 0)
+
+    aggregated: Dict[str, Any] = {
+        "quality_score": quality_sum / len(meta_list) if meta_list else 0.0,
+        "retries": retry_sum,
+        "chunks": meta_list,
+    }
+
+    joined_text = " ".join(t.strip() for t in all_text if t)
+    return {"text": joined_text, "metadata": aggregated}

--- a/docpipe/utils.py
+++ b/docpipe/utils.py
@@ -1,0 +1,26 @@
+try:
+    import tiktoken
+except Exception:  # pragma: no cover - optional dependency
+    tiktoken = None  # type: ignore
+
+from typing import List
+
+
+def split_into_chunks(text: str, max_tokens: int = 2048) -> List[str]:
+    """Split text into chunks of roughly ``max_tokens`` tokens.
+
+    Uses ``tiktoken`` when available. Otherwise falls back to a simple word
+    based heuristic assuming roughly one token per word.
+    """
+    if max_tokens <= 0:
+        return [text]
+
+    if tiktoken is None:
+        words = text.split()
+        chunks = [" ".join(words[i : i + max_tokens]) for i in range(0, len(words), max_tokens)]
+        return chunks or [""]
+
+    enc = tiktoken.get_encoding("cl100k_base")
+    tokens = enc.encode(text)
+    pieces = [tokens[i : i + max_tokens] for i in range(0, len(tokens), max_tokens)]
+    return [enc.decode(chunk) for chunk in pieces] or [""]


### PR DESCRIPTION
## Summary
- provide `split_into_chunks` utility using `tiktoken` when available
- run pipeline per chunk inside `process_text`
- aggregate metadata and concatenate chunk text
- test long text chunk handling

## Testing
- `pytest -q`
- `ruff check docpipe/pipeline.py`
- `ruff check docpipe/tests/test_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_683ae25d75508322baafbd8db8721899