### PR TITLE
Add click dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 ```
 
-3. Install dependencies:
+3. Install dependencies (the CLI uses the `click` package):
 ```bash
 pip install -r requirements.txt
 ```

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,7 @@
 numpy>=1.24.0
 pydantic>=2.5.0
 python-dotenv>=1.0.0
+click>=8.0
 fastapi>=0.104.0
 uvicorn>=0.24.0
 pytest>=7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ sacrebleu>=2.3.1
 pytest>=7.4.0
 ruff>=0.1.0
 mypy>=1.7.0
+click>=8.0
 streamlit>=1.29.0
 python-dotenv>=1.0.0
 pydantic>=2.5.0


### PR DESCRIPTION
## Summary
- add click>=8.0 to requirements files
- note click installation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae42eb9048322a1dc680374b29bd5