### PR TITLE
Add tests for utils.split_into_chunks

### DIFF
--- a/docpipe/tests/test_utils.py
+++ b/docpipe/tests/test_utils.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.utils import split_into_chunks  # noqa: E402
+
+
+def test_split_into_chunks_word_fallback(monkeypatch):
+    monkeypatch.setattr("docpipe.utils.tiktoken", None)
+    text = "one two three four five six seven eight nine"
+    chunks = split_into_chunks(text, max_tokens=3)
+    assert chunks == [
+        "one two three",
+        "four five six",
+        "seven eight nine",
+    ]
+
+
+def test_split_into_chunks_with_dummy_tokenizer(monkeypatch):
+    class DummyTokenizer:
+        def encode(self, text: str):
+            return text.split()
+
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    dummy_module = types.SimpleNamespace(get_encoding=lambda name: DummyTokenizer())
+    monkeypatch.setattr("docpipe.utils.tiktoken", dummy_module)
+
+    text = "one two three four five six seven eight nine"
+    chunks = split_into_chunks(text, max_tokens=4)
+    assert chunks == [
+        "one two three four",
+        "five six seven eight",
+        "nine",
+    ]


### PR DESCRIPTION
## Summary
- add new pytest module covering utils.split_into_chunks
- verify word-based fallback when `tiktoken` is missing
- simulate `tiktoken` usage with a dummy tokenizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aead0506083229b68edcf10809ef2