### PR TITLE
Add config precedence docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,16 @@ agents:
       style: "general"
 ```
 
+### Configuration Precedence
+
+The project loads configuration values in the following order:
+
+1. **Command line options** (`--output-dir`, `--config`) override all other settings.
+2. If `--config` is omitted but a `config.yaml` file exists in the working directory, its values are used.
+3. When neither of the above is provided, the defaults defined in `docpipe.config.Config` apply.
+
+All configuration is loaded via `Config.load()`, ensuring consistent behavior across the project.
+
 ## Error Handling
 
 ### Agent Failures

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ log_dir: "logs"
 ```
 This file will be loaded automatically when running the CLI from the same directory.
 
+#### Configuration Precedence
+
+Configuration is resolved in this order:
+
+1. **Command line options** such as `--output-dir` and `--config` take highest priority.
+2. If `--config` is not provided but `config.yaml` exists in the current directory, it is loaded.
+3. Otherwise, default values defined in `docpipe.config.Config` are used.
+
+All configuration is loaded via `Config.load()` so the rule is consistent across the project.
+
 ## Development
 
 ### Project Structure


### PR DESCRIPTION
## Summary
- document configuration precedence in AGENTS and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aedac5cf88322bab4e110b9000e05