### PR TITLE
Add customizable Translator config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,11 @@ llm:
   model: "gpt-4"
   temperature: 0.7
 
+translator:
+  model: "gpt-4"
+  temperature: 0.7
+  prompt: "Translate the following text to {target_lang}:\n{text}"
+
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -69,7 +69,11 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         # TODO: Add other extractors
     ]
     preprocessor = Preprocessor()
-    translator = Translator(cfg.llm.model, cfg.llm.temperature)
+    translator = Translator(
+        cfg.translator.model,
+        cfg.translator.temperature,
+        cfg.translator.prompt,
+    )
     proofreader = Proofreader()
     evaluator = Evaluator()
     fixer = Fixer()

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -19,9 +19,15 @@ class LLMConfig(BaseModel):
     model: str = "gpt-4"
     temperature: float = 0.7
 
+class TranslatorConfig(BaseModel):
+    model: str = "gpt-4"
+    temperature: float = 0.7
+    prompt: str = "Translate the following text to {target_lang}:\n{text}"
+
 class Config(BaseModel):
     pipeline: PipelineConfig = PipelineConfig()
     llm: LLMConfig = LLMConfig()
+    translator: TranslatorConfig = TranslatorConfig()
     output_dir: Path = Path("output")
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")

--- a/docpipe/processors/translator.py
+++ b/docpipe/processors/translator.py
@@ -10,11 +10,17 @@ from typing import Any, Dict
 class Translator:
     """Simple translator using OpenAI ChatCompletion."""
 
-    def __init__(self, model: str = "gpt-4", temperature: float = 0.7) -> None:
+    def __init__(
+        self,
+        model: str = "gpt-4",
+        temperature: float = 0.7,
+        prompt: str = "Translate the following text to {target_lang}:\n{text}",
+    ) -> None:
         if openai is None:
             raise ImportError("openai is required for Translator")
         self.model = model
         self.temperature = temperature
+        self.prompt = prompt
 
     def detect_language(self, text: str) -> str:
         """Very naive language detection."""
@@ -26,7 +32,7 @@ class Translator:
         """Translate text to the target language using ChatCompletion."""
         if target_lang == self.detect_language(text):
             return text
-        prompt = f"Translate the following text to {target_lang}:\n" + text
+        prompt = self.prompt.format(target_lang=target_lang, text=text)
         resp = openai.ChatCompletion.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -19,6 +19,26 @@ def test_load_default_file(tmp_path, monkeypatch):
     assert cfg.llm.model == "gpt-3"
 
 
+def test_translator_config_loaded(tmp_path):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(
+        "translator:\n  model: gpt-3\n  temperature: 0.5\n  prompt: t:{text}\n",
+        encoding="utf-8",
+    )
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+
+    assert cfg.translator.model == "gpt-3"
+    assert cfg.translator.temperature == 0.5
+    assert cfg.translator.prompt == "t:{text}"
+
+
 def test_load_no_file(tmp_path, monkeypatch):
     pytest.importorskip("yaml")
     cwd = os.getcwd()
@@ -28,5 +48,12 @@ def test_load_no_file(tmp_path, monkeypatch):
     finally:
         os.chdir(cwd)
     assert cfg.pipeline.quality_threshold == 0.85
+
+
+def test_translator_default_values():
+    cfg = Config()
+    assert cfg.translator.model == "gpt-4"
+    assert cfg.translator.temperature == 0.7
+    assert cfg.translator.prompt.startswith("Translate the following text")
 
 

--- a/docpipe/tests/test_translator.py
+++ b/docpipe/tests/test_translator.py
@@ -16,6 +16,16 @@ def _dummy_openai_module(result: str = "翻訳済み"):
     return types.SimpleNamespace(ChatCompletion=DummyChatCompletion)
 
 
+def _capture_openai_module(store: dict):
+    class DummyChatCompletion:
+        @staticmethod
+        def create(model, messages, temperature=0.0):
+            store["prompt"] = messages[0]["content"]
+            return {"choices": [{"message": {"content": "翻訳済み"}}]}
+
+    return types.SimpleNamespace(ChatCompletion=DummyChatCompletion)
+
+
 def test_translate(monkeypatch):
     monkeypatch.setattr(
         "docpipe.processors.translator.openai", _dummy_openai_module("こんにちは")
@@ -30,3 +40,14 @@ def test_detect_language_japanese(monkeypatch):
     monkeypatch.setattr("docpipe.processors.translator.openai", _dummy_openai_module())
     tr = Translator()
     assert tr.detect_language("これは日本語です") == "ja"
+
+
+def test_custom_prompt(monkeypatch):
+    store = {}
+    monkeypatch.setattr(
+        "docpipe.processors.translator.openai",
+        _capture_openai_module(store),
+    )
+    tr = Translator(prompt="P: {text} -> {target_lang}")
+    tr.translate("Hello", "fr")
+    assert store["prompt"] == "P: Hello -> fr"


### PR DESCRIPTION
## Summary
- support translator configuration with custom prompt
- update CLI to pass translator config
- allow overriding translator prompt in configuration
- test translator config loading and prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af7574d088322a180da95265cd76e