### PR TITLE
Add proofreader configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,12 @@ translator:
   temperature: 0.7
   prompt: "Translate the following text to {target_lang}:\n{text}"
 
+proofreader:
+  model: "gpt-4o"
+  style: "general"
+  temperature: 0.0
+  prompt: "Proofread the following text. Fix grammar, style, and readability issues in {style} style. Return only the corrected text."
+
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -74,7 +74,12 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         cfg.translator.temperature,
         cfg.translator.prompt,
     )
-    proofreader = Proofreader()
+    proofreader = Proofreader(
+        cfg.proofreader.model,
+        cfg.proofreader.style,
+        cfg.proofreader.temperature,
+        cfg.proofreader.prompt,
+    )
     evaluator = Evaluator()
     fixer = Fixer()
     

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -24,10 +24,20 @@ class TranslatorConfig(BaseModel):
     temperature: float = 0.7
     prompt: str = "Translate the following text to {target_lang}:\n{text}"
 
+class ProofreaderConfig(BaseModel):
+    model: str = "gpt-4o"
+    style: str = "general"
+    temperature: float = 0.0
+    prompt: str = (
+        "Proofread the following text. Fix grammar, style, and readability "
+        "issues in {style} style. Return only the corrected text."
+    )
+
 class Config(BaseModel):
     pipeline: PipelineConfig = PipelineConfig()
     llm: LLMConfig = LLMConfig()
     translator: TranslatorConfig = TranslatorConfig()
+    proofreader: ProofreaderConfig = ProofreaderConfig()
     output_dir: Path = Path("output")
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")

--- a/docpipe/processors/proofreader.py
+++ b/docpipe/processors/proofreader.py
@@ -10,21 +10,25 @@ class Proofreader:
     """Grammar and style proofreader using OpenAI ChatCompletion."""
 
     def __init__(
-        self, model: str = "gpt-4o", style: str = "general", temperature: float = 0.0
-
+        self,
+        model: str = "gpt-4o",
+        style: str = "general",
+        temperature: float = 0.0,
+        prompt: str = (
+            "Proofread the following text. Fix grammar, style, and readability "
+            "issues in {style} style. Return only the corrected text."
+        ),
     ) -> None:
         if openai is None:
             raise ImportError("openai is required for Proofreader")
         self.model = model
         self.style = style
         self.temperature = temperature
+        self.prompt = prompt
 
     def proofread(self, text: str) -> str:
         """Return text corrected by ChatGPT."""
-        prompt = (
-            "Proofread the following text. Fix grammar, style, and readability "
-            f"issues in {self.style} style. Return only the corrected text."
-        )
+        prompt = self.prompt.format(style=self.style)
         resp = openai.ChatCompletion.create(
             model=self.model,
             messages=[

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -57,3 +57,32 @@ def test_translator_default_values():
     assert cfg.translator.prompt.startswith("Translate the following text")
 
 
+def test_proofreader_config_loaded(tmp_path):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(
+        "proofreader:\n  model: p1\n  style: fancy\n  temperature: 0.2\n  prompt: P {style}\n",
+        encoding="utf-8",
+    )
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+
+    assert cfg.proofreader.model == "p1"
+    assert cfg.proofreader.style == "fancy"
+    assert cfg.proofreader.temperature == 0.2
+    assert cfg.proofreader.prompt == "P {style}"
+
+
+def test_proofreader_default_values():
+    cfg = Config()
+    assert cfg.proofreader.model == "gpt-4o"
+    assert cfg.proofreader.style == "general"
+    assert cfg.proofreader.temperature == 0.0
+    assert "{style}" in cfg.proofreader.prompt
+
+


### PR DESCRIPTION
## Summary
- support configuration of proofreader processor
- make Proofreader configurable and use config in CLI
- update default `config.yaml`
- test new configuration options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af8cfb524832287ad16403568546c