### PR TITLE
Move CLI imports to top

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -1,6 +1,24 @@
 import click
 from pathlib import Path
 from typing import List, Optional
+import json
+import hashlib
+import re
+
+from .config import Config
+from .extractors.youtube import YouTubeExtractor
+from .extractors.pdf import PDFExtractor
+from .extractors.ocr_pdf import OCRPDFExtractor
+from .extractors.web import WebExtractor
+from .extractors.audio import AudioExtractor
+from .processors import (
+    Preprocessor,
+    Translator,
+    Proofreader,
+    Evaluator,
+    Fixer,
+)
+from .pipeline import process_text
 
 
 def _expand_sources(source_paths: List[str]) -> List[str]:
@@ -20,23 +38,6 @@ def _expand_sources(source_paths: List[str]) -> List[str]:
         else:
             expanded.append(src)
     return expanded
-from .config import Config
-from .extractors.youtube import YouTubeExtractor
-from .extractors.pdf import PDFExtractor
-from .extractors.ocr_pdf import OCRPDFExtractor
-from .extractors.web import WebExtractor
-from .extractors.audio import AudioExtractor
-from .processors import (
-    Preprocessor,
-    Translator,
-    Proofreader,
-    Evaluator,
-    Fixer,
-)
-from .pipeline import process_text
-import json
-import hashlib
-import re
 
 @click.group()
 def cli():


### PR DESCRIPTION
## Summary
- reorder `docpipe/cli.py` so all imports precede `_expand_sources`
- keep `_expand_sources` right after the imports

## Testing
- `ruff check docpipe | head -n 20`
- `ruff check docpipe | grep E402 -n`

------
https://chatgpt.com/codex/tasks/task_e_683afebb33108322b2bb557ea8203a98