### PR TITLE
Fix unused import in tests

### DIFF
--- a/docpipe/tests/test_cli.py
+++ b/docpipe/tests/test_cli.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 


### PR DESCRIPTION
## Summary
- remove unused `Path` import from `test_cli.py`

## Testing
- `ruff check docpipe/tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_683aff7675808322892f74dfa44c6fb3