### PR TITLE
Fix evaluator quality typing

### DIFF
--- a/docpipe/pipeline.py
+++ b/docpipe/pipeline.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List
 
 from .config import PipelineConfig
 from .processors import Translator, Proofreader, Evaluator, Fixer
+from .processors.evaluator import EvaluationResult
 from .utils import split_into_chunks
 
 
@@ -26,8 +27,8 @@ def _process_chunk(
         text = pf["text"]
         metadata["proofread_quality"] = pf.get("quality_score")
 
-        eval_result = evaluator.evaluate(text)
-        quality = eval_result["quality_score"]
+        eval_result: EvaluationResult = evaluator.evaluate(text)
+        quality: float = eval_result["quality_score"]
         metadata.update(eval_result)
 
         if quality >= cfg.quality_threshold:

--- a/docpipe/processors/evaluator.py
+++ b/docpipe/processors/evaluator.py
@@ -8,7 +8,14 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     sacrebleu = None  # type: ignore
 
-from typing import Dict, Optional
+from typing import Dict, Optional, TypedDict
+
+
+class EvaluationResult(TypedDict):
+    grammar_error_rate: float
+    readability_score: float
+    bleu_score: Optional[float]
+    quality_score: float
 
 
 class Evaluator:
@@ -39,7 +46,7 @@ class Evaluator:
         result = sacrebleu.corpus_bleu([text], [[reference]])
         return float(result.score)
 
-    def evaluate(self, text: str, reference: Optional[str] = None) -> Dict[str, Optional[float]]:
+    def evaluate(self, text: str, reference: Optional[str] = None) -> EvaluationResult:
         """Return quality metrics for given text."""
         err_rate = self.grammar_error_rate(text)
         readability = self.readability_score(text)


### PR DESCRIPTION
## Summary
- ensure Evaluator returns a typed dictionary so `quality_score` is always float
- import and use the typed `EvaluationResult` inside the pipeline
- run `mypy` and `pytest`

## Testing
- `python -m mypy docpipe`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b026182448322b93e43b4ac12167d