### PR TITLE
Update dependencies for YAML and OCR support

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -11,6 +11,7 @@ from .extractors.pdf import PDFExtractor
 from .extractors.ocr_pdf import OCRPDFExtractor
 from .extractors.web import WebExtractor
 from .extractors.audio import AudioExtractor
+from .extractors.plain import PlainTextExtractor
 from .processors import (
     Preprocessor,
     Translator,
@@ -67,6 +68,7 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         PDFExtractor(),
         OCRPDFExtractor(),
         AudioExtractor(cfg.whisper.model),
+        PlainTextExtractor(),
         # TODO: Add other extractors
     ]
     preprocessor = Preprocessor()

--- a/docpipe/extractors/__init__.py
+++ b/docpipe/extractors/__init__.py
@@ -7,6 +7,7 @@ except Exception:  # pragma: no cover - optional
 
 from .pdf import PDFExtractor
 from .ocr_pdf import OCRPDFExtractor
+from .plain import PlainTextExtractor
 
 try:  # Optional dependency
     from .web import WebExtractor
@@ -18,7 +19,7 @@ try:  # Optional dependency
 except Exception:  # pragma: no cover - optional
     AudioExtractor = None  # type: ignore
 
-__all__ = ["BaseExtractor", "PDFExtractor", "OCRPDFExtractor"]
+__all__ = ["BaseExtractor", "PDFExtractor", "OCRPDFExtractor", "PlainTextExtractor"]
 
 if AudioExtractor is not None:
     __all__.insert(1, "AudioExtractor")

--- a/docpipe/extractors/plain.py
+++ b/docpipe/extractors/plain.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from .base import BaseExtractor
+
+
+class PlainTextExtractor(BaseExtractor):
+    """Extractor for plain text and Markdown files."""
+
+    SUPPORTED_EXTENSIONS: Tuple[str, ...] = (".txt", ".md")
+
+    def can_handle(self, source: str) -> bool:
+        """Check if the source is a plain text or Markdown file."""
+        return source.lower().endswith(self.SUPPORTED_EXTENSIONS)
+
+    def extract(self, source: str, **kwargs: Any) -> Dict[str, Any]:
+        """Read the file and return its text."""
+        file_path = Path(source)
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {source}")
+
+        text = file_path.read_text(encoding="utf-8")
+        metadata = {
+            "source_type": "plain",
+            "file_name": file_path.name,
+        }
+        return {"text": text, "metadata": metadata}

--- a/docpipe/processors/evaluator.py
+++ b/docpipe/processors/evaluator.py
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     sacrebleu = None  # type: ignore
 
-from typing import Dict, Optional, TypedDict
+from typing import Optional, TypedDict
 
 
 class EvaluationResult(TypedDict):

--- a/docpipe/tests/test_plain.py
+++ b/docpipe/tests/test_plain.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from docpipe.extractors.plain import PlainTextExtractor  # noqa: E402
+
+
+def test_can_handle_plain():
+    extractor = PlainTextExtractor()
+    assert extractor.can_handle("sample.txt")
+    assert extractor.can_handle("sample.MD")
+    assert not extractor.can_handle("sample.pdf")
+
+
+def test_extract_success(tmp_path):
+    file = tmp_path / "sample.txt"
+    file.write_text("hello", encoding="utf-8")
+    extractor = PlainTextExtractor()
+    result = extractor.extract(str(file))
+    assert result["text"] == "hello"
+    assert result["metadata"]["source_type"] == "plain"
+    assert result["metadata"]["file_name"] == "sample.txt"
+
+
+def test_extract_file_not_found():
+    extractor = PlainTextExtractor()
+    with pytest.raises(FileNotFoundError):
+        extractor.extract("missing.txt")

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,3 +12,6 @@ flake8>=6.1.0
 mypy>=1.5.1
 pytesseract>=0.3.10
 pdf2image>=1.16.3
+
+PyYAML>=6.0
+Pillow>=10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,8 @@ uvicorn>=0.24.0
 numpy>=1.24.0
 torch>=2.1.0
 transformers>=4.36.0 
+
+PyYAML>=6.0
+pytesseract>=0.3.10
+pdf2image>=1.16.3
+Pillow>=10.0.0


### PR DESCRIPTION
## Summary
- add `PyYAML`, `pytesseract`, `pdf2image`, and `Pillow` to runtime requirements
- include `PyYAML` and `Pillow` in CI requirements
- clean unused import in `Evaluator`

## Testing
- `ruff check .`
- `mypy docpipe` *(fails: missing optional dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b043972c88322a1b41158e1c8d383