### PR TITLE
Ensure single blank line between paragraphs

### DIFF
--- a/docpipe/processors/preprocessor.py
+++ b/docpipe/processors/preprocessor.py
@@ -25,19 +25,28 @@ class Preprocessor:
         """Restore line breaks by merging lines inside paragraphs."""
         lines = text.splitlines()
         restored: list[str] = []
+        punct = (".", "?", "!", "。", "？", "！", "：", ":")
         for line in lines:
             stripped = line.strip()
             if not stripped:
-                restored.append("")
+                if restored and restored[-1] != "":
+                    restored.append("")
                 continue
 
             if (
                 restored
                 and restored[-1]
-                and not restored[-1].endswith((".", "?", "!", "。", "？", "！", "：", ":"))
+                and not restored[-1].endswith(punct)
             ):
                 restored[-1] += " " + stripped
             else:
+                if (
+                    restored
+                    and restored[-1]
+                    and restored[-1].endswith(punct)
+                    and (len(restored) == 1 or restored[-2] != "")
+                ):
+                    restored.append("")
                 restored.append(stripped)
         return "\n".join(restored)
 

--- a/docpipe/tests/test_preprocessor.py
+++ b/docpipe/tests/test_preprocessor.py
@@ -24,3 +24,17 @@ def test_correct_ocr_errors():
     assert "fi" in processed
     assert '"test"' in processed
     assert "- example" in processed
+
+
+def test_paragraph_break_inserts_blank_line():
+    text = "First paragraph.\nSecond paragraph."
+    pre = Preprocessor()
+    processed = pre.process(text)
+    assert processed == "First paragraph.\n\nSecond paragraph."
+
+
+def test_multiple_blank_lines_collapse_to_one():
+    text = "First.\n\n\nSecond."
+    pre = Preprocessor()
+    processed = pre.process(text)
+    assert processed == "First.\n\nSecond."


### PR DESCRIPTION
## Summary
- ensure restore_line_breaks inserts a blank line for new paragraphs
- collapse extra blanks and add tests for the behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685616711a3c832285446ed4ff7438a0