### PR TITLE
Implement LLM disclaimer removal in Fixer

### DIFF
--- a/docpipe/processors/fixer.py
+++ b/docpipe/processors/fixer.py
@@ -30,6 +30,23 @@ class Fixer:
         text = re.sub(r" {2,}", " ", text)
         return text
 
+    def remove_llm_disclaimers(self, text: str) -> str:
+        """Remove LLM-generated disclaimer phrases from the text."""
+        patterns = [
+            r"ここでは.*?を修正しました",  # "Here we fixed ~"
+            r"こちらが翻訳です",         # "Here is the translation"
+        ]
+
+        lines = text.splitlines()
+        cleaned_lines = []
+        for line in lines:
+            if any(re.search(p, line) for p in patterns):
+                continue
+            cleaned_lines.append(line)
+
+        cleaned_text = "\n".join(cleaned_lines)
+        return cleaned_text.strip()
+
     def fix_speech_recognition_errors(self, text: str) -> str:
         """Fix common speech recognition errors in Japanese text."""
         # 音声認識でよく発生する誤認識パターン
@@ -343,7 +360,10 @@ class Fixer:
         
         # 4. 構造の改善（最後に実行して他の処理で上書きされないようにする）
         text = self.improve_structure(text)
-        
+
+        # 5. LLM 生成物のディスクレーマーを削除
+        text = self.remove_llm_disclaimers(text)
+
         changed = text != original
         return {"text": text, "changed": changed}
 

--- a/docpipe/tests/test_fixer.py
+++ b/docpipe/tests/test_fixer.py
@@ -25,3 +25,18 @@ def test_fix_common_typos():
     text = "teh quick brown fox"
     result = fixer.process(text)
     assert "the quick brown fox" == result["text"]
+
+
+def test_remove_llm_disclaimer_fix_note():
+    fixer = Fixer()
+    text = "ここでは文章を修正しました。\n実際の内容です。"
+    result = fixer.process(text)
+    assert "ここでは" not in result["text"]
+    assert result["text"].startswith("実際の内容です")
+
+
+def test_remove_llm_disclaimer_translation_note():
+    fixer = Fixer()
+    text = "こちらが翻訳です:\nHello"
+    result = fixer.process(text)
+    assert result["text"] == "Hello"


### PR DESCRIPTION
## Summary
- add a `remove_llm_disclaimers` helper in `Fixer`
- strip typical phrases like "ここでは～を修正しました" or "こちらが翻訳です"
- invoke this cleanup inside `Fixer.process`
- test disclaimer removal in `test_fixer.py`

## Testing
- `pytest docpipe/tests/test_fixer.py::test_remove_llm_disclaimer_fix_note -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859695a4c808322ac60f351b9361c9e