### PR TITLE
Add output_extension option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,15 @@ text-agent process --output-dir output/ "input.pdf"
 
 ### Output File Naming
 
-Files are saved with the format: `{YYMMDD}_{sequence:03d}_{meaningful_name}.txt`
+Files are saved with the format:
+`{YYMMDD}_{sequence:03d}_{meaningful_name}{output_extension}`
 
 Examples:
-- `250115_001_OpenAI_GPT4_1_発表.txt`
-- `250115_002_YouTube動画の文字起こし.txt`
-- `250115_003_技術文書.txt`
+- `250115_001_OpenAI_GPT4_1_発表.md`
+- `250115_002_YouTube動画の文字起こし.md`
+- `250115_003_技術文書.md`
+
+Set `output_extension` in `config.yaml` to change the extension (e.g. `.txt`).
 
 The meaningful name is extracted from metadata in this priority order:
 1. Title from source
@@ -147,6 +150,7 @@ whisper:
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"
+output_extension: ".md"
 ```
 
 ### Configuration Options

--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,4 @@ whisper:
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"
+output_extension: ".md"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -152,7 +152,9 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
             # Fallback to source-based slug
             meaningful_name = re.sub(r"[^a-zA-Z0-9_-]", "_", source.split("/")[-1])
         
-        output_file = cfg.output_dir / f"{timestamp}_{index_counter:03d}_{meaningful_name}.txt"
+        output_file = cfg.output_dir / (
+            f"{timestamp}_{index_counter:03d}_{meaningful_name}{cfg.output_extension}"
+        )
         output_file.parent.mkdir(parents=True, exist_ok=True)
         output_file.write_text(result['text'], encoding='utf-8')
 

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -51,6 +51,7 @@ class Config(BaseModel):
     output_dir: Path = Path("output")
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")
+    output_extension: str = ".md"
 
     @classmethod
     def from_yaml(cls, path: str) -> "Config":
@@ -59,6 +60,8 @@ class Config(BaseModel):
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
         cfg = cls(**data)
+        # ensure new option has default when missing
+        cfg.output_extension = data.get("output_extension", ".md")
         # force default models regardless of file values for consistency
         cfg.translator.model = "gpt-4.1-mini"
         cfg.proofreader.model = "gpt-4.1-mini"
@@ -84,4 +87,5 @@ class Config(BaseModel):
                 data = self.model_dump()  # Pydantic v2
             except AttributeError:  # pragma: no cover - Pydantic v1 fallback
                 data = self.dict()  # type: ignore[attr-defined]
+            data["output_extension"] = self.output_extension
             yaml.dump(data, f, allow_unicode=True)

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -113,3 +113,23 @@ def test_whisper_default_values():
     assert cfg.whisper.language is None
 
 
+def test_output_extension_default():
+    cfg = Config()
+    assert cfg.output_extension == ".md"
+
+
+def test_output_extension_loaded(tmp_path):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("output_extension: .txt\n", encoding="utf-8")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+
+    assert cfg.output_extension == ".txt"
+
+


### PR DESCRIPTION
## Summary
- support configurable `output_extension` in `Config`
- write/read this setting with YAML
- use the extension when creating output files
- document option in README and default config
- test new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596cf427e8832292c609bf9c82816f