### PR TITLE
Add Markdown heading conversion to Fixer

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -87,7 +87,7 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         cfg.proofreader.prompt,
     )
     evaluator = Evaluator()
-    fixer = Fixer()
+    fixer = Fixer(cfg.enable_markdown_headings)
     spellchecker = SpellChecker()
     
     # Process each source

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -52,6 +52,7 @@ class Config(BaseModel):
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")
     output_extension: str = ".md"
+    enable_markdown_headings: bool = True
 
     @classmethod
     def from_yaml(cls, path: str) -> "Config":
@@ -62,6 +63,7 @@ class Config(BaseModel):
         cfg = cls(**data)
         # ensure new option has default when missing
         cfg.output_extension = data.get("output_extension", ".md")
+        cfg.enable_markdown_headings = data.get("enable_markdown_headings", True)
         # force default models regardless of file values for consistency
         cfg.translator.model = "gpt-4.1-mini"
         cfg.proofreader.model = "gpt-4.1-mini"

--- a/docpipe/processors/fixer.py
+++ b/docpipe/processors/fixer.py
@@ -4,6 +4,9 @@ from typing import Any, Dict
 class Fixer:
     """Enhanced error correction agent with text structure improvements."""
 
+    def __init__(self, enable_markdown_headings: bool = True) -> None:
+        self.enable_markdown_headings = enable_markdown_headings
+
     def remove_duplicate_lines(self, text: str) -> str:
         lines = text.splitlines()
         cleaned: list[str] = []
@@ -33,8 +36,8 @@ class Fixer:
     def remove_llm_disclaimers(self, text: str) -> str:
         """Remove LLM-generated disclaimer phrases from the text."""
         patterns = [
-            r"ここでは.*?を修正しました",  # "Here we fixed ~"
-            r"こちらが翻訳です",         # "Here is the translation"
+            r"(?:^#\s*)?ここでは.*?を修正しました",  # "Here we fixed ~"
+            r"(?:^#\s*)?こちらが翻訳です",         # "Here is the translation"
         ]
 
         lines = text.splitlines()
@@ -292,10 +295,15 @@ class Fixer:
         result_lines = []
         
         for i, line in enumerate(lines):
+            is_heading = self._is_heading(line)
+
+            if is_heading and self.enable_markdown_headings and not line.lstrip().startswith("#"):
+                line = "# " + line.strip()
+
             result_lines.append(line)
-            
+
             # 見出しの後に改行を追加
-            if self._is_heading(line):
+            if is_heading:
                 # 次の行が空でない場合は空行を追加
                 if i + 1 < len(lines) and lines[i + 1].strip() != "":
                     result_lines.append("")

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -133,3 +133,23 @@ def test_output_extension_loaded(tmp_path):
     assert cfg.output_extension == ".txt"
 
 
+def test_markdown_heading_flag_default():
+    cfg = Config()
+    assert cfg.enable_markdown_headings
+
+
+def test_markdown_heading_flag_loaded(tmp_path):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("enable_markdown_headings: false\n", encoding="utf-8")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+
+    assert not cfg.enable_markdown_headings
+
+

--- a/docpipe/tests/test_fixer.py
+++ b/docpipe/tests/test_fixer.py
@@ -39,4 +39,18 @@ def test_remove_llm_disclaimer_translation_note():
     fixer = Fixer()
     text = "こちらが翻訳です:\nHello"
     result = fixer.process(text)
-    assert result["text"] == "Hello"
+    assert result["text"] == "# Hello"
+
+
+def test_markdown_heading_conversion():
+    fixer = Fixer()
+    text = "Introduction\nThis is body."
+    result = fixer.process(text)
+    assert result["text"] == "# Introduction\n\nThis is body."
+
+
+def test_disable_markdown_heading_conversion():
+    fixer = Fixer(enable_markdown_headings=False)
+    text = "Overview\nText"
+    result = fixer.process(text)
+    assert result["text"] == "Overview\n\nText"


### PR DESCRIPTION
## Summary
- allow Fixer to prepend '# ' when a line looks like a heading
- support toggling via `enable_markdown_headings` config option
- update CLI to use the new flag
- handle disclaimers with optional heading markup
- test heading conversion and config loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596f2b44b883228919d4f9f46f7d47