### PR TITLE
Add Marker PDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ source venv311/bin/activate  # On Windows: venv311\Scripts\activate
 pip install -e .
 ```
 
-4. Set up environment variables:
+4. Install the Marker PDF backend (optional but recommended for PDFs):
+```bash
+pip install marker-pdf
+```
+
+5. Set up environment variables:
 ```bash
 # Create .env file with your API keys
 echo "OPENAI_API_KEY=your_openai_api_key_here" > .env
@@ -58,6 +63,7 @@ echo "OPENAI_API_KEY=your_openai_api_key_here" > .env
 1. Clone and setup as above, then install dependencies:
 ```bash
 pip install -r requirements.txt
+pip install marker-pdf  # optional for PDF extraction
 ```
 
 ## Usage
@@ -241,6 +247,7 @@ pytest docpipe/tests/
 - OpenAI API key (for LLM features)
 - Java (for LanguageTool)
 - Tesseract (for OCR features)
+- marker-pdf (for PDF extraction)
 
 ## License
 

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from .config import Config
 from .extractors.youtube import YouTubeExtractor
 from .extractors.pdf import PDFExtractor
-from .extractors.ocr_pdf import OCRPDFExtractor
 from .extractors.ocr_image import OCRImageExtractor
 from .extractors.web import WebExtractor
 from .extractors.audio import AudioExtractor

--- a/docpipe/extractors/marker_pdf.py
+++ b/docpipe/extractors/marker_pdf.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import Tuple, List
+
+try:
+    import marker_pdf  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    marker_pdf = None  # type: ignore
+
+
+def to_text_with_layout(pdf_path: str) -> Tuple[str, List[str]]:
+    """Extract text and layout information using marker-pdf."""
+    if marker_pdf is None:
+        raise ImportError("marker-pdf is required for PDF extraction")
+    return marker_pdf.to_text_with_layout(Path(pdf_path))

--- a/docpipe/tests/test_pdf.py
+++ b/docpipe/tests/test_pdf.py
@@ -1,22 +1,40 @@
 import os
 import sys
-import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from docpipe.extractors.pdf import PDFExtractor  # noqa: E402
+import pytest
 
 
 def test_extract_with_layout(tmp_path, monkeypatch):
     fake_pdf = tmp_path / "sample.pdf"
     fake_pdf.write_text("dummy")
 
-    dummy_module = types.SimpleNamespace(
-        to_text_with_layout=lambda p: ("PDF TEXT", ["page1", "page2"])
+    monkeypatch.setattr(
+        "docpipe.extractors.pdf.marker_pdf.to_text_with_layout",
+        lambda p: ("PDF TEXT", ["page1", "page2"]),
     )
-    monkeypatch.setattr("docpipe.extractors.pdf.marker_pdf", dummy_module)
 
     extractor = PDFExtractor()
     result = extractor.extract(str(fake_pdf))
     assert result["text"] == "PDF TEXT"
     assert result["metadata"]["layout"] == ["page1", "page2"]
+
+
+def test_extract_missing_dependency(tmp_path, monkeypatch):
+    fake_pdf = tmp_path / "sample.pdf"
+    fake_pdf.write_text("dummy")
+
+    def raise_import(_):
+        raise ImportError("missing")
+
+    monkeypatch.setattr(
+        "docpipe.extractors.pdf.marker_pdf.to_text_with_layout",
+        raise_import,
+    )
+    monkeypatch.setattr("docpipe.extractors.pdf.pypdfium2", None)
+
+    extractor = PDFExtractor()
+    with pytest.raises(ImportError):
+        extractor.extract(str(fake_pdf))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@ tiktoken>=0.5.0
 yt-dlp>=2023.12.30
 openai-whisper>=20231117
 trafilatura>=1.6.1
+# marker-pdf provides PDF text extraction
 marker-pdf>=0.1.0
+# pypdfium2 can be installed for fallback extraction
 # marker-ocr-pdf>=0.1.0  # このパッケージは利用できないためコメントアウト
 language-tool-python>=2.7.1
 sacrebleu>=2.3.1


### PR DESCRIPTION
## Summary
- add marker-pdf dependency info
- create `marker_pdf` wrapper module
- switch `PDFExtractor` to prefer marker-pdf
- adjust CLI imports
- update tests for marker backend

## Testing
- `ruff check .`
- `mypy .` *(fails: missing library stubs for setuptools and language_tool_python)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859760a39d88322a38ee82e5db0dc6f