### PR TITLE
Respect min_improvement in pipeline loop

### DIFF
--- a/docpipe/pipeline.py
+++ b/docpipe/pipeline.py
@@ -41,13 +41,10 @@ def _process_chunk(
         if retries >= cfg.pipeline.max_retries:
             break
 
-        # 品質が閾値を下回っている場合は、最大リトライ回数まで試行
-        # 改善判定をより柔軟にする
-        if retries > 0:  # 最初のリトライ以外で改善判定
+        # リトライ時の改善幅が設定値以下なら停止
+        if retries > 0:
             improvement = quality - prev_quality
-            # 改善が負の場合のみ停止（悪化した場合）
-            # 浮動小数の誤差を考慮してわずかな変動は無視
-            if improvement < -0.011:  # 大幅な悪化の場合のみ停止
+            if improvement <= cfg.pipeline.min_improvement:
                 break
 
         fix_result = fixer.process(text)

--- a/docpipe/tests/test_pipeline.py
+++ b/docpipe/tests/test_pipeline.py
@@ -64,8 +64,7 @@ def test_improvement_and_threshold():
 def test_min_improvement_breaks_loop():
     cfg = Config()
     cfg.pipeline = PipelineConfig(quality_threshold=0.9, max_retries=5, min_improvement=0.1)
-    # 改善が小さく、大幅な悪化がない場合のテスト
-    # 新しいロジックでは大幅な悪化（-0.01未満）の場合のみ停止
+    # 改善幅が設定値以下の場合にループが停止することを確認
     proofreader = DummyProofreader([0.4, 0.45, 0.44, 0.43, 0.42, 0.41])  # 徐々に悪化
     evaluator = DummyEvaluator([0.4, 0.45, 0.44, 0.43, 0.42, 0.41])  # 徐々に悪化
     translator = DummyTranslator()
@@ -74,9 +73,9 @@ def test_min_improvement_breaks_loop():
     spellchecker = SpellChecker(quality_threshold=0.3)
 
     result = process_text("bad", cfg, translator, proofreader, evaluator, fixer, spellchecker)
-    # 新しいロジックでは大幅な悪化がない限り最大リトライ回数まで実行
-    assert result["metadata"]["retries"] == 5
-    assert result["metadata"]["quality_score"] == 0.41
+    # 2回目の評価で改善幅が0.05となり、min_improvement=0.1以下なので停止
+    assert result["metadata"]["retries"] == 1
+    assert result["metadata"]["quality_score"] == 0.45
 
 
 def test_long_text_chunking():


### PR DESCRIPTION
## Summary
- halt retry loop when improvement falls below `cfg.pipeline.min_improvement`
- update pipeline tests for new improvement logic

## Testing
- `pytest docpipe/tests/test_pipeline.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685978e8cdac8322884bb58a0599ca43