### PR TITLE
Enhance language detection and readability scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A unified document conversion framework that transforms various input sources in
 ### Quality Assurance & Processing
 - **Intelligent Translation**: Multi-language to Japanese translation (translator returns only the translated text)
 - **Grammar Checking**: LanguageTool integration for error detection. Proofreader keeps the original meaning, leaves unknown terms untouched, and outputs only the corrected text.
-- **Readability Scoring**: LLM-based quality evaluation
+- **Readability Scoring**: LLM-based quality evaluation with optional MeCab morphological analysis
+- **Accurate Language Detection**: Differentiates Japanese and Chinese using langdetect
 - **Automatic Retry**: Smart retry logic for quality improvement
 - **Text Fixing**: Mechanical fixes for common transcription errors
 - **Spell Checking**: Optional spell correction for obvious errors
@@ -248,6 +249,8 @@ pytest docpipe/tests/
 - Java (for LanguageTool)
 - Tesseract (for OCR features)
 - marker-pdf (for PDF extraction)
+- langdetect (for improved language detection)
+- fugashi/MeCab (for Japanese readability metrics)
 
 ## License
 
@@ -269,3 +272,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **Python Code Preservation**: Maintains syntax integrity for code files
 - **Spell Checker Integration**: Optional spell correction for obvious errors
 - **Package Installation**: Easy global installation with `pip install -e .`
+- **Language Detection Upgrade**: Japanese and Chinese are distinguished using langdetect
+- **MeCab Readability Metrics**: Word-based scoring when fugashi is installed

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -17,3 +17,5 @@ tiktoken>=0.5.0
 language-tool-python>=2.7.1
 PyYAML>=6.0
 Pillow>=10.0.0
+langdetect>=1.0.9
+fugashi>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ PyYAML>=6.0
 pytesseract>=0.3.10
 pdf2image>=1.16.3
 Pillow>=10.0.0
+langdetect>=1.0.9
+fugashi>=1.3.0


### PR DESCRIPTION
## Summary
- add langdetect and fugashi to dependencies
- improve Evaluator language detection with langdetect fallback
- add morphological analysis option for Japanese readability
- document new features and requirements
- test language detection for Chinese and readability with MeCab

## Testing
- `ruff check .`
- `mypy docpipe`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68597a7367348322b78d0ea9ed3f5aff