### PR TITLE
Improve Japanese grammar tokenization

### DIFF
--- a/docpipe/processors/evaluator.py
+++ b/docpipe/processors/evaluator.py
@@ -60,8 +60,19 @@ class Evaluator:
         return "en"
 
     def grammar_error_rate(self, text: str) -> float:
+        """Return grammar error rate using token count heuristics."""
         matches = self.tool.check(text)
-        tokens = max(len(text.split()), 1)
+        language = self.detect_language(text)
+
+        if language == "ja":
+            if self.tagger is not None:
+                tokens = len([tok.surface for tok in self.tagger(text)])
+            else:
+                tokens = len(re.findall(r"\S", text))
+        else:
+            tokens = len(text.split())
+
+        tokens = max(tokens, 1)
         return len(matches) / tokens
 
     def readability_score_japanese(self, text: str) -> float:


### PR DESCRIPTION
## Summary
- improve grammar error rate calculation for Japanese by using the fugashi tagger when available
- add character-based fallback when fugashi isn't installed
- extend evaluator tests for tagger presence and absence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597fa8742c8322bfd18dc969b7f4b9