### PR TITLE
Improve BLEU scoring for Japanese

### DIFF
--- a/docpipe/processors/evaluator.py
+++ b/docpipe/processors/evaluator.py
@@ -159,7 +159,15 @@ class Evaluator:
     def bleu_score(self, text: str, reference: str) -> float:
         if sacrebleu is None:
             raise ImportError("sacrebleu is required for BLEU score")
-        result = sacrebleu.corpus_bleu([text], [[reference]])
+        tokenize = None
+        if self.detect_language(text) == "ja":
+            tokenize = "ja-mecab"
+
+        if tokenize is None:
+            result = sacrebleu.corpus_bleu([text], [[reference]])
+        else:
+            result = sacrebleu.corpus_bleu([text], [[reference]], tokenize=tokenize)
+
         return float(result.score)
 
     def evaluate(self, text: str, reference: Optional[str] = None) -> EvaluationResult:


### PR DESCRIPTION
## Summary
- use mecab tokenization for Japanese BLEU scores
- ensure BLEU still defaults for other languages
- test BLEU scoring with Japanese tokenizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685980b2494083229b22ff28c31bc965