### PR TITLE
Add glossary module and integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,10 @@ proofreader:
   enabled: true
   prompt: "Proofread the following text. Fix grammar, style, and readability issues in {style} style. 文の意味を変えないこと。未知の用語はそのまま残すこと。結果だけを出力してください。"
 
+glossary:
+  path:
+  enabled: false
+
 whisper:
   model: "large"
   language:

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -13,6 +13,7 @@ from .extractors.ocr_image import OCRImageExtractor
 from .extractors.web import WebExtractor
 from .extractors.audio import AudioExtractor
 from .extractors.plain import PlainTextExtractor
+from .glossary import Glossary
 from .processors import (
     Preprocessor,
     Translator,
@@ -86,7 +87,13 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
         cfg.proofreader.prompt,
     )
     evaluator = Evaluator()
-    fixer = Fixer(cfg.enable_markdown_headings)
+    glossary = None
+    if cfg.glossary.enabled and cfg.glossary.path:
+        try:
+            glossary = Glossary(str(cfg.glossary.path))
+        except Exception as exc:  # pragma: no cover - CLI only
+            click.echo(f"Failed to load glossary: {exc}")
+    fixer = Fixer(cfg.enable_markdown_headings, glossary=glossary)
     spellchecker = SpellChecker()
     
     # Process each source

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -41,6 +41,10 @@ class ProofreaderConfig(BaseModel):
 class WhisperConfig(BaseModel):
     model: str = "large"
     language: Optional[str] = None
+class GlossaryConfig(BaseModel):
+    path: Optional[Path] = None
+    enabled: bool = False
+
 
 class Config(BaseModel):
     pipeline: PipelineConfig = PipelineConfig()
@@ -48,6 +52,7 @@ class Config(BaseModel):
     translator: TranslatorConfig = TranslatorConfig()
     proofreader: ProofreaderConfig = ProofreaderConfig()
     whisper: WhisperConfig = WhisperConfig()
+    glossary: GlossaryConfig = GlossaryConfig()
     output_dir: Path = Path("output")
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")

--- a/docpipe/glossary.py
+++ b/docpipe/glossary.py
@@ -1,0 +1,72 @@
+import csv
+from pathlib import Path
+from typing import Dict
+
+try:  # optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional
+    yaml = None  # type: ignore
+
+import re
+
+
+class Glossary:
+    """Load bilingual glossary from CSV or YAML and replace terms."""
+
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+        self.mapping: Dict[str, str] = {}
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            raise FileNotFoundError(self.path)
+        if self.path.suffix.lower() in {".yaml", ".yml"}:
+            self._load_yaml()
+        elif self.path.suffix.lower() == ".csv":
+            self._load_csv()
+        else:
+            raise ValueError("Unsupported glossary format: %s" % self.path)
+
+    def _add_entry(self, ja: str, en: str) -> None:
+        if ja:
+            self.mapping[ja] = ja
+        if en:
+            self.mapping[en] = ja
+
+    def _load_csv(self) -> None:
+        with open(self.path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                ja = row.get("ja") or row.get("jp") or row.get("term") or ""
+                en = row.get("en") or ""
+                if ja or en:
+                    self._add_entry(ja.strip(), en.strip())
+
+    def _load_yaml(self) -> None:
+        if yaml is None:
+            raise ImportError("PyYAML is required for YAML glossary")
+        with open(self.path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            ja = str(item.get("ja", "")).strip()
+            en = str(item.get("en", "")).strip()
+            if ja or en:
+                self._add_entry(ja, en)
+
+    def replace(self, text: str) -> str:
+        if not self.mapping:
+            return text
+        # replace longer terms first
+        items = sorted(self.mapping.items(), key=lambda x: len(x[0]), reverse=True)
+        for term, canonical in items:
+            if not term:
+                continue
+            if re.fullmatch(r"[A-Za-z0-9_\-]+", term):
+                pattern = r"(?<![A-Za-z0-9_])" + re.escape(term) + r"(?![A-Za-z0-9_])"
+            else:
+                pattern = re.escape(term)
+            text = re.sub(pattern, canonical, text)
+        return text

--- a/docpipe/processors/fixer.py
+++ b/docpipe/processors/fixer.py
@@ -1,12 +1,19 @@
 import itertools
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from ..glossary import Glossary
 
 class Fixer:
     """Enhanced error correction agent with text structure improvements."""
 
-    def __init__(self, enable_markdown_headings: bool = True) -> None:
+    def __init__(
+        self,
+        enable_markdown_headings: bool = True,
+        glossary: Optional[Glossary] = None,
+    ) -> None:
         self.enable_markdown_headings = enable_markdown_headings
+        self.glossary = glossary
 
     def remove_duplicate_lines(self, text: str) -> str:
         lines = (next(g) for _, g in itertools.groupby(text.splitlines()))
@@ -46,6 +53,11 @@ class Fixer:
 
         cleaned_text = "\n".join(cleaned_lines)
         return cleaned_text.strip()
+
+    def apply_glossary(self, text: str) -> str:
+        if self.glossary is None:
+            return text
+        return self.glossary.replace(text)
 
     def fix_speech_recognition_errors(self, text: str) -> str:
         """Fix common speech recognition errors in Japanese text."""
@@ -369,6 +381,9 @@ class Fixer:
         # 5. LLM 生成物のディスクレーマーを削除
         text = self.remove_llm_disclaimers(text)
 
+        # 6. 用語集による置換
+        text = self.apply_glossary(text)
+
         changed = text != original
         return {"text": text, "changed": changed}
 
@@ -415,7 +430,10 @@ class Fixer:
         
         # 7. 構造の改善
         text = self.improve_structure(text)
-        
+
+        # 8. 用語集による置換
+        text = self.apply_glossary(text)
+
         changed = text != original
         return {"text": text, "changed": changed}
 

--- a/docpipe/tests/test_config.py
+++ b/docpipe/tests/test_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os
 import pytest
 
@@ -153,3 +154,24 @@ def test_markdown_heading_flag_loaded(tmp_path):
     assert not cfg.enable_markdown_headings
 
 
+
+def test_glossary_config_loaded(tmp_path):
+    pytest.importorskip("yaml")
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("glossary:\n  path: terms.csv\n  enabled: true\n", encoding="utf-8")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = Config.load()
+    finally:
+        os.chdir(cwd)
+
+    assert cfg.glossary.path == Path("terms.csv")
+    assert cfg.glossary.enabled
+
+
+def test_glossary_config_defaults():
+    cfg = Config()
+    assert cfg.glossary.path is None
+    assert not cfg.glossary.enabled

--- a/docpipe/tests/test_fixer.py
+++ b/docpipe/tests/test_fixer.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 from docpipe.processors.fixer import Fixer  # noqa: E402
 
+from docpipe.glossary import Glossary
 
 def test_remove_duplicate_lines():
     fixer = Fixer()
@@ -54,3 +55,11 @@ def test_disable_markdown_heading_conversion():
     text = "Overview\nText"
     result = fixer.process(text)
     assert result["text"] == "Overview\n\nText"
+
+def test_apply_glossary(tmp_path):
+    gfile = tmp_path / "gl.csv"
+    gfile.write_text("ja,en\n人工知能,AI\n", encoding="utf-8")
+    glossary = Glossary(str(gfile))
+    fixer = Fixer(glossary=glossary)
+    result = fixer.process("AIを使う")
+    assert "人工知能" in result["text"]

--- a/docpipe/tests/test_glossary.py
+++ b/docpipe/tests/test_glossary.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import yaml
+
+from docpipe.glossary import Glossary
+
+
+def test_load_csv(tmp_path):
+    gfile = tmp_path / "gl.csv"
+    gfile.write_text("ja,en\n人工知能,AI\n", encoding="utf-8")
+    gl = Glossary(str(gfile))
+    assert gl.replace("AIを研究する") == "人工知能を研究する"
+
+
+def test_load_yaml(tmp_path):
+    gfile = tmp_path / "gl.yaml"
+    yaml.dump([{"ja": "パソコン", "en": "computer"}], gfile.open("w", encoding="utf-8"), allow_unicode=True)
+    gl = Glossary(str(gfile))
+    assert gl.replace("computerを使う") == "パソコンを使う"
+


### PR DESCRIPTION
## Summary
- implement `Glossary` module for CSV/YAML term replacement
- hook Glossary into `Fixer` and CLI
- extend config with `glossary` section
- add tests for glossary loading and config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685985e910e08322b8a06ad2727ce3e7