### PR TITLE
Skip glossary tests if yaml unavailable

### DIFF
--- a/docpipe/tests/test_glossary.py
+++ b/docpipe/tests/test_glossary.py
@@ -1,6 +1,10 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import pytest
+
+pytest.importorskip("yaml")
+
 import yaml
 
 from docpipe.glossary import Glossary


### PR DESCRIPTION
## Summary
- skip the glossary tests if PyYAML isn't installed

## Testing
- `pytest docpipe/tests/test_glossary.py -q`
- `pytest docpipe/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68598b4312388322b9798fcf2952c267