### PR TITLE
Use single glossary instance in CLI

### DIFF
--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -96,13 +96,6 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
     )
     evaluator = Evaluator()
 
-    glossary = None
-    if cfg.glossary.enabled and cfg.glossary.path:
-        try:
-            glossary = Glossary(str(cfg.glossary.path))
-        except Exception as exc:  # pragma: no cover - CLI only
-            click.echo(f"Failed to load glossary: {exc}")
-
     fixer = Fixer(cfg.enable_markdown_headings, glossary=glossary)
     spellchecker = SpellChecker()
     


### PR DESCRIPTION
## Summary
- avoid reloading glossary in CLI and share one instance across processors

## Testing
- `pytest docpipe/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859977441b883228cc28a9a566a5648