### PR TITLE
Handle optional OpenAI import for diff processor

### DIFF
--- a/docpipe/processors/diff_processor.py
+++ b/docpipe/processors/diff_processor.py
@@ -2,7 +2,12 @@ import os
 import re
 from datetime import datetime
 from typing import List, Dict, Any
-from openai import OpenAI
+try:
+    import openai
+    from openai import OpenAI
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+    OpenAI = None  # type: ignore
 
 from ..utils.markdown_utils import (
     is_markdown_file, 

--- a/docpipe/tests/test_diff_processor.py
+++ b/docpipe/tests/test_diff_processor.py
@@ -1,4 +1,7 @@
 import pytest
+
+pytest.importorskip("openai")
+
 from unittest.mock import Mock, patch
 from docpipe.processors.diff_processor import DiffProcessor
 


### PR DESCRIPTION
## Summary
- make `diff_processor` gracefully handle missing `openai`
- skip diff processor tests when `openai` isn't installed

## Testing
- `pytest -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862d442642c83228c92e8f890123c42