### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ whisper:
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"
+log_level: "INFO"
 output_extension: ".md"
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -44,4 +44,5 @@ whisper:
 output_dir: "output"
 temp_dir: "temp"
 log_dir: "logs"
+log_level: "INFO"
 output_extension: ".md"

--- a/docpipe/cli.py
+++ b/docpipe/cli.py
@@ -5,6 +5,7 @@ from itertools import chain
 import json
 import re
 from datetime import datetime
+import logging
 
 from .config import Config
 from .extractors.youtube import YouTubeExtractor
@@ -52,7 +53,8 @@ def cli():
 @click.argument("sources", nargs=-1, required=True)
 @click.option("--config", "-c", type=click.Path(exists=True), help="Path to config file")
 @click.option("--output-dir", "-o", type=click.Path(), help="Output directory")
-def process(sources: List[str], config: Optional[str], output_dir: Optional[str]) -> None:
+@click.option("--log-level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]), help="Logging level")
+def process(sources: List[str], config: Optional[str], output_dir: Optional[str], log_level: Optional[str]) -> None:
     """Process one or more document sources.
 
     Sources can be individual files, URLs, or directories. Directory paths are
@@ -61,6 +63,9 @@ def process(sources: List[str], config: Optional[str], output_dir: Optional[str]
     cfg = Config.load(config)
     if output_dir:
         cfg.output_dir = Path(output_dir)
+    if log_level:
+        cfg.log_level = log_level
+    logging.basicConfig(level=getattr(logging, cfg.log_level.upper(), logging.INFO))
 
     sources = _expand_sources(list(sources))
     

--- a/docpipe/config.py
+++ b/docpipe/config.py
@@ -69,6 +69,7 @@ class Config(BaseModel):
     output_dir: Path = Path("output")
     temp_dir: Path = Path("temp")
     log_dir: Path = Path("logs")
+    log_level: str = "INFO"
     output_extension: str = ".md"
     enable_markdown_headings: bool = True
 
@@ -82,6 +83,7 @@ class Config(BaseModel):
         # ensure new option has default when missing
         cfg.output_extension = data.get("output_extension", ".md")
         cfg.enable_markdown_headings = data.get("enable_markdown_headings", True)
+        cfg.log_level = data.get("log_level", "INFO")
         # force default models regardless of file values for consistency
         cfg.translator.model = "gpt-4.1-mini"
         cfg.proofreader.model = "gpt-4.1-mini"
@@ -108,4 +110,5 @@ class Config(BaseModel):
             except AttributeError:  # pragma: no cover - Pydantic v1 fallback
                 data = self.dict()  # type: ignore[attr-defined]
             data["output_extension"] = self.output_extension
+            data["log_level"] = self.log_level
             yaml.dump(data, f, allow_unicode=True)

--- a/docpipe/processors/diff_processor.py
+++ b/docpipe/processors/diff_processor.py
@@ -1,14 +1,17 @@
 import os
 import re
+import logging
 from datetime import datetime
 from typing import List, Dict, Any
 from openai import OpenAI
 
 from ..utils.markdown_utils import (
-    is_markdown_file, 
+    is_markdown_file,
     extract_critical_markdown_blocks,
     restore_critical_markdown_blocks
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DiffProcessor:
@@ -209,7 +212,7 @@ class DiffProcessor:
         with open(filepath, 'w', encoding='utf-8') as f:
             f.write(text)
         
-        print(f"DEBUG: Saved improved text for chunk {chunk_num} to {filepath}")
+        logger.debug("Saved improved text for chunk %s to %s", chunk_num, filepath)
         return filepath
     
     def process(self, text: str) -> Dict[str, Any]:
@@ -217,15 +220,18 @@ class DiffProcessor:
         if not text.strip():
             return {"text": text, "metadata": {"iterations": 0, "changed": False}}
         
-        print(f"DEBUG: DiffProcessor processing text of length {len(text)}")
+        logger.debug("DiffProcessor processing text of length %s", len(text))
         
         # Markdownファイルの場合は見出し・表・画像を絶対保護
         critical_blocks = {}
         if is_markdown_file(text):
-            print("DEBUG: Markdown file detected")
+            logger.debug("Markdown file detected")
             # 見出し・表・画像を絶対保護
             text, critical_blocks = extract_critical_markdown_blocks(text)
-            print(f"DEBUG: Protected {len(critical_blocks)} critical blocks (headers, tables, images)")
+            logger.debug(
+                "Protected %s critical blocks (headers, tables, images)",
+                len(critical_blocks),
+            )
         
         # 通常のDiffProcessor処理
         original_text = text
@@ -235,13 +241,13 @@ class DiffProcessor:
         
         # Split into chunks if needed
         chunks = self.split_text_into_chunks(text)
-        print(f"DEBUG: Split into {len(chunks)} chunks")
+        logger.debug("Split into %s chunks", len(chunks))
         
         if len(chunks) > 1:
             # Process each chunk separately
             improved_chunks = []
             for i, chunk in enumerate(chunks):
-                print(f"DEBUG: Processing chunk {i+1}/{len(chunks)}")
+                logger.debug("Processing chunk %s/%s", i + 1, len(chunks))
                 improved_chunk = self._process_chunk(chunk, i+1)
                 improved_chunks.append(improved_chunk)
             
@@ -254,9 +260,9 @@ class DiffProcessor:
         
         # 見出し・表・画像を必ず復元
         if critical_blocks:
-            print("DEBUG: Restoring critical markdown blocks (headers, tables, images)")
+            logger.debug("Restoring critical markdown blocks (headers, tables, images)")
             improved_text = restore_critical_markdown_blocks(improved_text, critical_blocks)
-            print(f"DEBUG: Restored {len(critical_blocks)} critical blocks")
+            logger.debug("Restored %s critical blocks", len(critical_blocks))
         
         changed = improved_text != original_text
         
@@ -272,8 +278,8 @@ class DiffProcessor:
     
     def _process_chunk(self, chunk: str, chunk_num: int) -> str:
         """Process a single chunk of text."""
-        print(f"=== DiffProcessor: 入力チャンク（最初の100文字） ===")
-        print(repr(chunk[:100]))
+        logger.debug("=== DiffProcessor: 入力チャンク（最初の100文字） ===")
+        logger.debug(repr(chunk[:100]))
         
         original_chunk = chunk
         improved_chunk = chunk
@@ -283,8 +289,8 @@ class DiffProcessor:
                 # Generate improvement prompt
                 prompt = self.generate_diff_prompt(improved_chunk)
                 
-                print(f"=== DiffProcessor: LLM送信前テキスト（最初の100文字） ===")
-                print(repr(improved_chunk[:100]))
+                logger.debug("=== DiffProcessor: LLM送信前テキスト（最初の100文字） ===")
+                logger.debug(repr(improved_chunk[:100]))
                 
                 # Call LLM for direct text improvement
                 client = OpenAI()
@@ -295,22 +301,25 @@ class DiffProcessor:
                 )
                 
                 improved_response = resp.choices[0].message.content.strip()
-                print(f"=== DiffProcessor: LLM返却テキスト（最初の100文字） ===")
-                print(repr(improved_response[:100]))
-                print(f"DEBUG: Received improvement response of length {len(improved_response)}")
+                logger.debug("=== DiffProcessor: LLM返却テキスト（最初の100文字） ===")
+                logger.debug(repr(improved_response[:100]))
+                logger.debug(
+                    "Received improvement response of length %s",
+                    len(improved_response),
+                )
                 
                 # Validate the response
                 if improved_response and improved_response != original_chunk:
                     improved_chunk = improved_response
-                    print(f"DEBUG: Chunk {chunk_num} improved successfully")
+                    logger.debug("Chunk %s improved successfully", chunk_num)
                     break
                 else:
-                    print(f"DEBUG: No improvement in attempt {attempt + 1}")
+                    logger.debug("No improvement in attempt %s", attempt + 1)
                     
             except Exception as e:
-                print(f"DEBUG: Error in attempt {attempt + 1}: {e}")
+                logger.debug("Error in attempt %s: %s", attempt + 1, e)
                 if attempt == self.max_retries - 1:
-                    print(f"DEBUG: Max retries reached for chunk {chunk_num}, keeping original")
+                    logger.debug("Max retries reached for chunk %s, keeping original", chunk_num)
         
         # Save iteration result
         if self.output_history:

--- a/docpipe/tests/test_cli.py
+++ b/docpipe/tests/test_cli.py
@@ -82,7 +82,7 @@ def test_cli_uses_whisper_model(monkeypatch):
     cfg.whisper.model = "custom"
     monkeypatch.setattr(cli_module.Config, "load", classmethod(lambda cls, path=None: cfg))
 
-    cli_module.process.callback(["dummy"], None, None)
+    cli_module.process.callback(["dummy"], None, None, None)
 
     assert called["model"] == "custom"
 
@@ -149,7 +149,7 @@ def test_cli_uses_progressbar(monkeypatch, tmp_path):
     cfg.output_dir = tmp_path
     monkeypatch.setattr(cli_module.Config, "load", classmethod(lambda cls, path=None: cfg))
 
-    cli_module.process.callback(["dummy1", "dummy2"], None, None)
+    cli_module.process.callback(["dummy1", "dummy2"], None, None, None)
 
     assert called["called"]
     assert called["length"] == 2


### PR DESCRIPTION
## Summary
- configure log level in config and CLI
- add project logger and replace prints with debug logs
- document log_level option
- update CLI tests for new arg

## Testing
- `pytest -q` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6862d447f1a883228ccdb9c1f2e08921