### PR TITLE
Refactor processors init

### DIFF
--- a/docpipe/processors/__init__.py
+++ b/docpipe/processors/__init__.py
@@ -1,10 +1,10 @@
 from .preprocessor import Preprocessor
 from .fixer import Fixer
-from .translator import Translator
-from .proofreader import Proofreader
-from .evaluator import Evaluator
-from .spellchecker import SpellChecker
-from .diff_processor import DiffProcessor
+
+try:  # Optional dependency
+    from .diff_processor import DiffProcessor
+except Exception:  # pragma: no cover - optional
+    DiffProcessor = None  # type: ignore
 
 try:  # Optional dependency
     from .translator import Translator
@@ -12,29 +12,27 @@ except Exception:  # pragma: no cover - optional
     Translator = None  # type: ignore
 
 try:  # Optional dependency
-    from .evaluator import Evaluator
-except Exception:  # pragma: no cover - optional
-    Evaluator = None  # type: ignore
-
-try:  # Optional dependency
     from .proofreader import Proofreader
 except Exception:  # pragma: no cover - optional
     Proofreader = None  # type: ignore
+
+try:  # Optional dependency
+    from .evaluator import Evaluator
+except Exception:  # pragma: no cover - optional
+    Evaluator = None  # type: ignore
 
 try:  # Optional dependency
     from .spellchecker import SpellChecker
 except Exception:  # pragma: no cover - optional
     SpellChecker = None  # type: ignore
 
-__all__ = [
-    "Preprocessor",
-    "Fixer",
-    "Translator",
-    "Proofreader",
-    "Evaluator",
-    "SpellChecker",
-    "DiffProcessor"
-]
+__all__ = ["Preprocessor", "Fixer"]
+
+if DiffProcessor is not None:
+    __all__.append("DiffProcessor")
+
+if SpellChecker is not None:
+    __all__.append("SpellChecker")
 
 if Translator is not None:
     __all__.append("Translator")
@@ -44,6 +42,3 @@ if Proofreader is not None:
 
 if Evaluator is not None:
     __all__.append("Evaluator")
-
-if SpellChecker is not None:
-    __all__.append("SpellChecker")

--- a/docpipe/tests/test_processors_init.py
+++ b/docpipe/tests/test_processors_init.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+def test_import_processors_without_optional_deps(monkeypatch):
+    for pkg in [
+        "openai",
+        "language_tool_python",
+        "sacrebleu",
+        "langdetect",
+        "fugashi",
+    ]:
+        monkeypatch.setitem(sys.modules, pkg, None)
+
+    for mod in list(sys.modules):
+        if mod.startswith("docpipe.processors"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    processors = importlib.import_module("docpipe.processors")
+
+    assert processors.Preprocessor is not None
+    assert processors.Fixer is not None
+    assert processors.SpellChecker is not None
+    assert len(processors.__all__) == len(set(processors.__all__))


### PR DESCRIPTION
## Summary
- clean up processor package imports
- avoid duplicate names in `__all__`
- add regression test for importing processors without optional dependencies

## Testing
- `pytest docpipe/tests/test_processors_init.py -q`
- `pytest -q` *(fails: openai/tiktoken missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862d446a62c83228c690d7e4b5e318f